### PR TITLE
Detect whole GID, not parts of it

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -52,7 +52,7 @@ function createUser() {
     fi
 
     if [ -n "$gid" ]; then
-        if ! $(cat /etc/group | cut -d: -f3 | grep -q "$gid"); then
+        if ! $(cat /etc/group | cut -d: -f3 | grep -qw "$gid"); then
             groupadd --gid $gid "group_$gid"
         fi
 


### PR DESCRIPTION
This PR fixes an issue I encountered with entrypoint script. When checking if given GID is already present in `/etc/group`, it's possible that a longer GID that contains the specified GID will be falsely matched by grep, resulting in group **not** being created by the subsequent `groupadd` command. This in turn results in `useradd` failing on unknown GID parameter. A notable example is group `nogroup`, with GID `65533`, which can easily contain multiple other, valid GIDs.

That issue is fixed by adding `-w` option to `grep`, which makes it match only full words.